### PR TITLE
feat: add OrbitItemFreezeOnMouseOver component and update dependencies

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,17 +1,38 @@
 'use client';
 import { OrbitPath, OrbitItem } from 'react-orbit-component';
 import Image from 'next/image';
-
+import React from 'react';
+import { Props } from 'useful-react-types';
 const SHARED_CLASSNAME = 'w-10 h-10 bg-zinc-800 border-white/20 border-2 rounded-full flex items-center justify-center text-lg';
-
+const OrbitItemFreezeOnMouseOver = ({ children, radius }: Props.ForceChildren & {radius?: number}) => {
+  const [isFreeze, setIsFreeze] = React.useState(false);
+  return (
+    <OrbitItem
+      direction="clockwise"
+      className="w-10 h-10 bg-zinc-800 border-white/20 border-2 rounded-full flex items-center justify-center text-lg cursor-pointer hover:scale-110"
+      step={isFreeze ? 0 : 0.2}
+      delay={0.1}
+      radius={radius}
+      style={{
+        transition: 'transform 0.1s ease-in-out',
+      }}
+      onMouseOver={(e) => {
+        setIsFreeze(true);
+      }}
+      onMouseOut={(e) => {
+        setIsFreeze(false);
+      }}
+    >
+      {children}
+    </OrbitItem>
+  );
+}
 export default function Page(): JSX.Element {
   return (
     <main>
       <div className="flex items-center justify-center min-h-screen">
         <OrbitPath type="circle" className="absolute w-[25vh] h-[25vh] bg-transparent rounded-full border-2 border-white/10">
-          <OrbitItem direction="clockwise" className={SHARED_CLASSNAME}>
-            💻
-          </OrbitItem>
+          <OrbitItemFreezeOnMouseOver>🐒</OrbitItemFreezeOnMouseOver>
         </OrbitPath>
 
         <OrbitPath type="circle" className="absolute w-[45vh] h-[45vh] bg-transparent rounded-full border-2 border-white/10">

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,8 @@
     "next": "^14.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-orbit-component": "workspace:*"
+    "react-orbit-component": "workspace:*",
+    "useful-react-types": "^1.0.2"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^14.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-orbit-component:
         specifier: workspace:*
         version: link:../../packages/react-orbit
+      useful-react-types:
+        specifier: ^1.0.2
+        version: 1.0.2
     devDependencies:
       '@next/eslint-plugin-next':
         specifier: ^14.0.4


### PR DESCRIPTION
- Added a new component called `OrbitItemFreezeOnMouseOver` which allows freezing the animation on mouse over.
- Updated dependencies to include `useful-react-types` version 1.0.2.