### PR TITLE
chore: update sizes and styles of orbit paths and items in Page compo…

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-zinc-900 max-h-screen h-screen;
+  @apply bg-zinc-900 max-h-screen h-screen w-screen overflow-hidden;
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -31,11 +31,11 @@ export default function Page(): JSX.Element {
   return (
     <main>
       <div className="flex items-center justify-center min-h-screen">
-        <OrbitPath type="circle" className="absolute w-[25vh] h-[25vh] bg-transparent rounded-full border-2 border-white/10">
+        <OrbitPath type="circle" className="absolute w-[10rem] h-[10rem] bg-transparent rounded-full border-2 border-white/10">
           <OrbitItemFreezeOnMouseOver>🐒</OrbitItemFreezeOnMouseOver>
         </OrbitPath>
 
-        <OrbitPath type="circle" className="absolute w-[45vh] h-[45vh] bg-transparent rounded-full border-2 border-white/10">
+        <OrbitPath type="circle" className="absolute md:w-[20rem] md:h-[20rem] w-[15rem] h-[15rem] bg-transparent rounded-full border-2 border-white/10">
           <OrbitItem direction="clockwise" startAngle={120} step={0.2} className={SHARED_CLASSNAME}>
             😀
           </OrbitItem>
@@ -49,7 +49,7 @@ export default function Page(): JSX.Element {
           </OrbitItem>
         </OrbitPath>
 
-        <OrbitPath type="circle" className="absolute w-[65vh] h-[65vh] bg-transparent rounded-full border-2 border-white/10">
+        <OrbitPath type="circle" className="absolute md:w-[30rem] md:h-[30rem] w-[20rem] h-[20rem] bg-transparent rounded-full border-2 border-white/10">
           <OrbitItem direction="counter-clockwise" startAngle={240} step={0.3} className={SHARED_CLASSNAME}>
             🚀
           </OrbitItem>


### PR DESCRIPTION
…nent

The sizes and styles of the orbit paths and items in the Page component have been updated. The `OrbitPath` components now have different width and height values, and the `OrbitItem` components have been adjusted accordingly. Additionally, the `body` CSS rule in the associated stylesheet has been modified to include `w-screen` and `overflow-hidden` classes.